### PR TITLE
Skip hidden directories in the main directory parser

### DIFF
--- a/shared/Module Entities/Module.ts
+++ b/shared/Module Entities/Module.ts
@@ -697,7 +697,8 @@ export class Module {
     // through these, creating Groups.
     let subdirectoryNames: string[] = FileSystem.readdirSync(directoryPath).filter(function (file) {
       let childPath = Path.join(directoryPath, file)
-      return FileSystem.statSync(childPath).isDirectory()
+      // skip hidden directories
+      return FileSystem.statSync(childPath).isDirectory() && !(/(^|\/)\.[^\/\.]/g).test(file)
     })
 
     // Ensure there are files in the modules directory


### PR DESCRIPTION
Hidden directory check in the main directory parser to skip creating groups for `.git` and other stuff. Got the regex from SO, hope it's working on all platforms (I've tested it only on mac). 